### PR TITLE
fix: skip docs setup when documentation is absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
-
       - name: Check for documentation
         id: check-docs
         run: |
@@ -204,6 +198,13 @@ jobs:
           else
             echo "docs-exist=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Install uv
+        if: steps.check-docs.outputs.docs-exist == 'true'
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
 
       - name: Build documentation
         if: steps.check-docs.outputs.docs-exist == 'true'


### PR DESCRIPTION
## Summary
- Move the documentation existence check before uv setup in the Documentation job
- Gate uv setup and mkdocs build so the job skips cleanly when docs are absent
- Preserve the rest of the CI workflow behavior

Closes #10