### PR TITLE
fix: enable PR review comments and skip Dependabot in Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,25 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: the action rejects bot-initiated workflows, and when Dependabot
+    # modifies workflow files the content differs from main causing a validation failure.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,8 +28,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            Review the changes in this pull request (${{ github.repository }}/pull/${{ github.event.pull_request.number }}).
+
+            Analyze the diff for:
+            - Logic errors and bugs
+            - Security vulnerabilities (SQL injection, auth issues, data exposure)
+            - Edge cases and regressions
+            - Code quality and maintainability issues
+
+            Post your findings as a PR review comment using:
+              gh pr review ${{ github.event.pull_request.number }} --comment -b "<your summary>"
+            If you find no significant issues, post a brief acknowledgement. Keep the review concise.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- **Grant write permissions** — `claude-code-review.yml` had `pull-requests: read` and `claude.yml` had `pull-requests: read` / `issues: read`. Without write access the action cannot post review comments. Changed both to `write`.
- **Replace plugin approach** — The previous config used `plugin_marketplaces` + `code-review@claude-code-plugins` which is the Team/Enterprise code review product. On Pro/Max, this ran silently and posted nothing. Replaced with a direct `prompt` that instructs Claude to post a summary comment via `gh pr review`.
- **Skip Dependabot PRs** — Two distinct failures were occurring on bot PRs:
  - *Any Dependabot PR*: `"Workflow initiated by non-human actor: dependabot[bot]"` — the action rejects bot-triggered runs
  - *Dependabot PRs that update workflow files* (PR #13): `"Workflow file must match default branch"` — security check fails when the workflow content differs from `main`
  - Added `if: github.event.pull_request.user.login != 'dependabot[bot]'` to skip both cases

## How to use @claude after merge

**Automated review** — Every non-Dependabot PR triggers `claude-code-review.yml` and Claude posts a summary comment.

**Interactive** — Mention `@claude` anywhere in a PR comment, PR review, or issue:
```
@claude review the security implications of this change
@claude fix the failing test in tests/unit/test_analytics.py
@claude summarize what changed in this PR
```

## Test plan

- [x] Open a new test PR after merge → `claude-review` job runs and posts a review comment
- [ ] Mention `@claude summarize this PR` in a PR comment → Claude responds in the thread
- [ ] Verify Dependabot PRs show `claude-review` as **skipped** instead of failed