### PR TITLE
chore: clean package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MoneyWiz MCP Server will be documented in this file.
 
-This project follows semantic versioning where possible. See `docs/ROADMAP.md` and future release documentation for compatibility expectations.
+This project follows semantic versioning where possible. See `docs/ROADMAP.md` and `docs/RELEASING.md` for compatibility expectations.
 
 ## Unreleased
 
@@ -14,6 +14,7 @@ This project follows semantic versioning where possible. See `docs/ROADMAP.md` a
 ### Changed
 
 - Tightened release/versioning policy, MCP compatibility expectations, and release checklist guidance.
+- Cleaned package metadata for the first stable baseline and future publishing workflows.
 
 ## 1.0.0 - TBD
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,22 +5,42 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "moneywiz-mcp-server"
 version = "1.0.0"
-description = "MCP server for MoneyWiz financial data integration"
+description = "Read-only MCP server for local MoneyWiz financial analytics"
 authors = [
-    {name = "MoneyWiz MCP Team", email = "dev@example.com"}
+    {name = "Juan Carlos Valerio Arrieta", email = "jcvalerio@gmail.com"}
+]
+maintainers = [
+    {name = "Juan Carlos Valerio Arrieta", email = "jcvalerio@gmail.com"}
 ]
 readme = "README.md"
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
-keywords = ["mcp", "moneywiz", "finance", "ai", "claude"]
+keywords = [
+    "ai",
+    "analytics",
+    "claude",
+    "finance",
+    "macos",
+    "mcp",
+    "model-context-protocol",
+    "moneywiz",
+    "personal-finance",
+    "sqlite",
+]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: MacOS X",
     "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Office/Business :: Financial",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
@@ -58,6 +78,8 @@ moneywiz-mcp-server = "moneywiz_mcp_server.main:cli_main"
 
 [project.urls]
 "Homepage" = "https://github.com/jcvalerio/moneywiz-mcp-server"
+"Documentation" = "https://github.com/jcvalerio/moneywiz-mcp-server#readme"
+"Changelog" = "https://github.com/jcvalerio/moneywiz-mcp-server/blob/main/CHANGELOG.md"
 "Bug Reports" = "https://github.com/jcvalerio/moneywiz-mcp-server/issues"
 "Source" = "https://github.com/jcvalerio/moneywiz-mcp-server"
 

--- a/src/moneywiz_mcp_server/__init__.py
+++ b/src/moneywiz_mcp_server/__init__.py
@@ -5,8 +5,8 @@ enabling AI assistants to perform financial analysis and transaction management.
 """
 
 __version__ = "1.0.0"
-__author__ = "MoneyWiz MCP Team"
-__email__ = "dev@example.com"
+__author__ = "Juan Carlos Valerio Arrieta"
+__email__ = "jcvalerio@gmail.com"
 
 # Re-export main components for easier imports
 from .config import Config


### PR DESCRIPTION
## Summary
- replace placeholder author/maintainer metadata with the project maintainer identity
- align package description, keywords, classifiers, license files, and project URLs for the v1.0.0 baseline
- update changelog notes for the release-foundation metadata cleanup

## Task
- Implements MW-005 from docs/ROADMAP.md.
- Chose MW-005 as the next smallest PR-able release-foundation task. GitHub project/issue seeding remains useful follow-up tracking work, but it mutates GitHub project state outside the branch/PR flow and the current token lacks project scope.

## Checks
- uv build
- uv run ruff check . --output-format=github
- uv run ruff format --check .
- uv run mypy src/ --install-types --non-interactive --no-strict-optional
- uv run pytest tests/
