### PR TITLE
ci: add GitHub release artifact workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release Artifacts
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.12.7"
+
+jobs:
+  build-release-artifacts:
+    name: Build and Upload Release Artifacts
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'v')
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(uv run python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_NAME#v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Package version $PACKAGE_VERSION does not match release tag $TAG_NAME"
+            exit 1
+          fi
+
+      - name: Build package artifacts
+        run: uv build
+
+      - name: Check package artifacts
+        run: uvx twine check dist/*
+
+      - name: Upload artifacts to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows semantic versioning where possible. See `docs/ROADMAP.md` a
 
 - Roadmap planning for release stability, binary distribution, onboarding, and feature completeness.
 - Stable-version usage and rollback guidance for source-checkout installs.
+- GitHub Release artifact workflow for source distribution and wheel uploads.
 
 ### Changed
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -154,6 +154,12 @@ uv sync --all-extras
   ```
 
 - [ ] Verify package artifacts are created under `dist/`.
+- [ ] Check package artifacts:
+
+  ```bash
+  uvx twine check dist/*
+  ```
+
 - [ ] Smoke test the built package where practical.
 - [ ] If binary release is configured in a later task, build the macOS binary and smoke test it.
 - [ ] Do not promise binary, Homebrew, or PyPI install paths until the corresponding release workflow exists and has been verified.
@@ -174,9 +180,10 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-- [ ] Create a GitHub Release from the tag.
-- [ ] Upload package artifacts from `dist/`.
+- [ ] Create and publish a GitHub Release from the tag.
+- [ ] Confirm the release workflow builds package artifacts and uploads `dist/*` to the GitHub Release.
 - [ ] Upload binary artifacts only if binary release support has been implemented and verified.
+- [ ] Do not publish to PyPI until the separate PyPI publishing workflow is implemented and configured.
 - [ ] Include install, upgrade, compatibility, and rollback instructions in release notes.
 
 ### 7. After release


### PR DESCRIPTION
## Description

Implements MW-006 by adding a GitHub Release workflow that builds package artifacts for published `v*` releases and uploads the generated source distribution and wheel to the GitHub Release.

## Scope

- Adds `.github/workflows/release.yml` triggered by GitHub Release publication.
- Verifies the release tag version matches `pyproject.toml`.
- Builds package artifacts with `uv build`.
- Checks artifacts with `twine check`.
- Uploads `dist/*` to the GitHub Release.
- Updates release documentation to reflect the automated artifact upload step.

Out of scope: PyPI publishing, binary packaging, and feature additions.

## Testing

- [x] `uv run ruff check . --output-format=github`
- [x] `uv run ruff format --check .`
- [x] `uv build`
- [x] `uvx twine check dist/*`
- [x] Pre-commit hooks run during commit
