### PR TITLE
docs: mark baseline release complete

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,7 +123,7 @@ Suggested labels:
 | MW-000 | Document release/versioning policy | P0 | XS | Done | TBD | #17 |
 | MW-001 | Add initial changelog | P0 | XS | Done | TBD | #15 |
 | MW-002 | Add release checklist | P0 | XS | Done | TBD | #17 |
-| MW-003 | Tag current stable baseline release | P0 | XS | In progress | TBD | TBD |
+| MW-003 | Tag current stable baseline release | P0 | XS | Done | TBD | #20 |
 | MW-004 | Document how existing users stay on a stable version | P0 | XS | Done | TBD | #17 |
 | MW-005 | Clean package metadata for publishing | P0 | XS | Done | TBD | #18 |
 | MW-006 | Add GitHub release workflow draft | P0 | S | Done | TBD | #19 |
@@ -197,7 +197,7 @@ Goal: create a stable baseline and release process before changing user-facing b
 - **Size:** XS
 - **Depends on:** MW-000, MW-001, MW-002
 - **Expected outcome:** Existing users have a stable tag they can pin to before larger roadmap work starts.
-- **Preparation status:** baseline metadata is being prepared for `v1.0.0` after PR #19. This task is not complete until a maintainer explicitly confirms tag and GitHub Release publication.
+- **Release status:** completed in `v1.0.0`; the annotated tag and GitHub Release were published from the PR #20 merge commit.
 - **Acceptance criteria:**
   - Maintainer selects baseline version, likely `v1.0.0` if current README/package claims production-ready 1.0.0.
   - Git tag is created from the chosen stable commit.


### PR DESCRIPTION
## Summary
- mark MW-003 as done now that v1.0.0 is tagged and published
- record that the baseline release was published from the PR #20 merge commit

## Checks
- uv run ruff check . --output-format=github
- uv run ruff format --check .

## Release verification
- Created annotated tag v1.0.0 at 4dd05f4
- Published GitHub Release: https://github.com/jcvalerio/moneywiz-mcp-server/releases/tag/v1.0.0
- Release artifact workflow succeeded: https://github.com/jcvalerio/moneywiz-mcp-server/actions/runs/25645207339
- Release assets uploaded: wheel and source tarball