### PR TITLE
ci: add PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,74 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12.7"
+
+jobs:
+  build-python-distributions:
+    name: Build Python Distributions
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'v')
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(uv run python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_NAME#v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Package version $PACKAGE_VERSION does not match release tag $TAG_NAME"
+            exit 1
+          fi
+
+      - name: Build package artifacts
+        run: uv build
+
+      - name: Check package artifacts
+        run: uvx twine check dist/*
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-python-distributions
+    if: startsWith(github.event.release.tag_name, 'v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/moneywiz-mcp-server
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: Publish package artifacts to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project follows semantic versioning where possible. See `docs/ROADMAP.md` a
 
 ## Unreleased
 
-No unreleased changes yet.
+### Added
+
+- PyPI publishing workflow draft using GitHub Actions trusted publishing and a protected `pypi` environment.
 
 ## 1.0.0 - 2026-05-10
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -162,7 +162,7 @@ uv sync --all-extras
 
 - [ ] Smoke test the built package where practical.
 - [ ] If binary release is configured in a later task, build the macOS binary and smoke test it.
-- [ ] Do not promise binary, Homebrew, or PyPI install paths until the corresponding release workflow exists and has been verified.
+- [ ] Do not promise binary, Homebrew, or PyPI install paths until the corresponding release channel has been published and verified.
 
 ### 5. Merge release metadata
 
@@ -183,7 +183,8 @@ git push origin vX.Y.Z
 - [ ] Create and publish a GitHub Release from the tag.
 - [ ] Confirm the release workflow builds package artifacts and uploads `dist/*` to the GitHub Release.
 - [ ] Upload binary artifacts only if binary release support has been implemented and verified.
-- [ ] Do not publish to PyPI until the separate PyPI publishing workflow is implemented and configured.
+- [ ] If publishing to PyPI, confirm the trusted publisher and GitHub `pypi` environment are configured, then approve the protected `pypi` deployment after reviewing the release.
+- [ ] If not publishing to PyPI for this release, do not approve the `pypi` deployment.
 - [ ] Include install, upgrade, compatibility, and rollback instructions in release notes.
 
 ### 7. After release
@@ -223,6 +224,34 @@ git fetch --tags
 git checkout v1.0.0
 uv sync --all-extras
 ```
+
+## PyPI Publishing
+
+PyPI publishing uses trusted publishing through GitHub Actions. Do not add a long-lived PyPI API token unless trusted publishing is unavailable.
+
+Required PyPI trusted publisher settings:
+
+- PyPI project name: `moneywiz-mcp-server`
+- Owner: `jcvalerio`
+- Repository name: `moneywiz-mcp-server`
+- Workflow name: `pypi-publish.yml`
+- Environment name: `pypi`
+
+Required GitHub environment:
+
+- Environment name: `pypi`
+- Required reviewer: at least one maintainer
+
+The `.github/workflows/pypi-publish.yml` workflow runs only when a GitHub Release is published with a tag that starts with `v`. It builds the source distribution and wheel, checks them with Twine, uploads them as workflow artifacts, and publishes them to PyPI only after the protected `pypi` environment is approved.
+
+Before approving PyPI publication:
+
+1. Confirm the GitHub Release tag matches `pyproject.toml`.
+2. Confirm the version has not already been published to PyPI.
+3. Confirm release notes and compatibility notes are final.
+4. Confirm source-checkout install guidance remains available for existing users.
+
+If a GitHub Release was already published before the PyPI workflow existed, do not reuse that release event. Publish a later version, such as a patch release, when PyPI availability is ready.
 
 ## Release Notes Template
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Suggested labels:
 | MW-008 | Add standalone macOS binary build workflow | P0 | M | Not started | TBD | TBD |
 | MW-009 | Add diagnostics command | P1 | M | Not started | TBD | TBD |
 | MW-010 | Improve Claude Desktop config generation | P1 | S | Not started | TBD | TBD |
-| MW-011 | Add PyPI publishing workflow draft | P1 | S | Not started | TBD | TBD |
+| MW-011 | Add PyPI publishing workflow draft | P1 | S | In progress | TBD | TBD |
 | MW-012 | Document `uvx` install path | P1 | XS | Not started | TBD | TBD |
 | MW-013 | Support database folder paths | P1 | XS | Not started | TBD | TBD |
 | MW-014 | Add exported backup detection to setup script | P1 | S | Not started | TBD | TBD |
@@ -298,6 +298,7 @@ Goal: make setup and troubleshooting easier for both existing and new users.
 - **Priority:** P1
 - **Size:** S
 - **Expected outcome:** Maintainers can publish releases to PyPI from GitHub Actions using trusted publishing or configured secrets.
+- **Implementation status:** workflow draft is being added with PyPI trusted publishing and the protected GitHub `pypi` environment.
 - **Acceptance criteria:**
   - Workflow triggers only on release/tag.
   - Includes build and artifact upload.


### PR DESCRIPTION
## Summary
- add a release-published PyPI workflow using trusted publishing and the protected pypi environment
- build, check, and upload package artifacts before the publish job
- document PyPI publishing setup and approval guidance in release instructions
- update changelog and roadmap tracking for MW-011

## PyPI/GitHub environment check
- GitHub environment pypi exists
- pypi environment has required reviewer configured: jcvalerio
- PyPI project endpoint currently returns 404, which is expected before first publish
- PyPI pending trusted publisher configuration cannot be verified through the GitHub API; confirm it in PyPI with workflow name pypi-publish.yml and environment pypi before approving a publish deployment

## Checks
- uv run ruff check . --output-format=github
- uv run ruff format --check .
- uv run pre-commit run --all-files
- uv build
- uvx twine check dist/*
- uv run pytest tests/

## Notes
- Workflow triggers only on GitHub Release publication for v* tags.
- No publishing happens on push or PR.
- PyPI publishing still requires protected environment approval.
- Source-checkout install guidance remains preserved.