### PR TITLE
chore: prepare v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,23 @@ This project follows semantic versioning where possible. See `docs/ROADMAP.md` a
 
 ## Unreleased
 
+No unreleased changes yet.
+
+## 1.0.1 - 2026-05-11
+
+Patch release to validate the PyPI publishing workflow without changing MCP behavior.
+
 ### Added
 
 - PyPI publishing workflow draft using GitHub Actions trusted publishing and a protected `pypi` environment.
+
+### Compatibility notes
+
+- Breaking changes: none.
+- MCP tool schema changes: none.
+- Configuration changes: none.
+- Financial calculation changes: none.
+- Existing source-checkout installs remain supported.
 
 ## 1.0.0 - 2026-05-10
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Suggested labels:
 | MW-008 | Add standalone macOS binary build workflow | P0 | M | Not started | TBD | TBD |
 | MW-009 | Add diagnostics command | P1 | M | Not started | TBD | TBD |
 | MW-010 | Improve Claude Desktop config generation | P1 | S | Not started | TBD | TBD |
-| MW-011 | Add PyPI publishing workflow draft | P1 | S | In progress | TBD | TBD |
+| MW-011 | Add PyPI publishing workflow draft | P1 | S | Done | TBD | #23 |
 | MW-012 | Document `uvx` install path | P1 | XS | Not started | TBD | TBD |
 | MW-013 | Support database folder paths | P1 | XS | Not started | TBD | TBD |
 | MW-014 | Add exported backup detection to setup script | P1 | S | Not started | TBD | TBD |
@@ -298,7 +298,7 @@ Goal: make setup and troubleshooting easier for both existing and new users.
 - **Priority:** P1
 - **Size:** S
 - **Expected outcome:** Maintainers can publish releases to PyPI from GitHub Actions using trusted publishing or configured secrets.
-- **Implementation status:** workflow draft is being added with PyPI trusted publishing and the protected GitHub `pypi` environment.
+- **Implementation status:** completed in PR #23 with PyPI trusted publishing and the protected GitHub `pypi` environment.
 - **Acceptance criteria:**
   - Workflow triggers only on release/tag.
   - Includes build and artifact upload.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moneywiz-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 description = "Read-only MCP server for local MoneyWiz financial analytics"
 authors = [
     {name = "Juan Carlos Valerio Arrieta", email = "jcvalerio@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "moneywiz-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- bump package version to 1.0.1
- move the PyPI publishing workflow note into the 1.0.1 changelog section
- mark MW-011 done after PR #23

## Compatibility
- Breaking changes: none
- MCP tool schema changes: none
- Configuration changes: none
- Financial calculation changes: none
- Existing source-checkout installs remain supported

## Checks
- uv lock --check
- uv run ruff check . --output-format=github
- uv run ruff format --check .
- uv run mypy src/ --install-types --non-interactive --no-strict-optional
- uv run pytest tests/
- uv build
- uvx twine check dist/*

## Release validation plan after merge
1. Tag merged main as v1.0.1.
2. Publish the GitHub Release for v1.0.1.
3. Verify Release Artifacts succeeds.
4. Verify Publish to PyPI pauses for the protected pypi environment.
5. Approve the pypi deployment only after confirming PyPI trusted publisher settings.
6. Verify https://pypi.org/project/moneywiz-mcp-server/1.0.1/.