### PR TITLE
fix: derive package version from metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This project follows semantic versioning where possible. See `docs/ROADMAP.md` a
 
 ## Unreleased
 
-No unreleased changes yet.
+### Added
+
+- Claude Desktop configuration example for running the published PyPI package with `uvx`.
+
+### Fixed
+
+- Package `__version__` now reflects installed distribution metadata instead of a hardcoded value.
 
 ## 1.0.1 - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ find ~ -name "*.sqlite*" 2>/dev/null | grep -i moneywiz
 
 ### 2. Add MCP Server Configuration
 
-Claude Desktop does not source your shell, so bare commands like `python` or `uv` won't be found. You must use the **absolute path** to the Python binary inside `.venv`.
+Claude Desktop does not source your shell, so bare commands like `python` or `uv` won't be found. Use absolute paths in the configuration.
+
+#### Option A: Source Checkout
+
+Use this option if you cloned the repository and ran `uv sync --all-extras`.
 
 ```json
 {
@@ -196,6 +200,41 @@ echo "$(pwd)/.venv/bin/python"
 The `.venv/bin/python` binary is self-contained — it does **not** require Python to be installed globally on your Mac.
 
 The `cwd` field is required so the server can locate the `.env` file with your database path.
+
+#### Option B: PyPI with `uvx`
+
+Use this option if you want Claude Desktop to run the published package without a source checkout. Because there is no checkout-local `.env` file in this mode, provide the MoneyWiz database path through the `env` block.
+
+First, find the absolute path to `uv`:
+
+```bash
+command -v uv
+# Example output: /Users/yourname/.local/bin/uv
+```
+
+Then configure Claude Desktop. Pin the package version for stable behavior, and replace `MONEYWIZ_DB_PATH` with your actual SQLite database path.
+
+```json
+{
+  "mcpServers": {
+    "moneywiz": {
+      "command": "/ABSOLUTE/PATH/TO/uv",
+      "args": [
+        "x",
+        "--from",
+        "moneywiz-mcp-server==1.0.1",
+        "moneywiz-mcp-server"
+      ],
+      "env": {
+        "MONEYWIZ_DB_PATH": "/ABSOLUTE/PATH/TO/ipadMoneyWiz.sqlite",
+        "MONEYWIZ_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
+
+If you prefer to use the newest published package instead of a pinned version, remove `==1.0.1`. Pinned versions are recommended for day-to-day use.
 
 ### 3. Restart Claude Desktop
 

--- a/src/moneywiz_mcp_server/__init__.py
+++ b/src/moneywiz_mcp_server/__init__.py
@@ -4,9 +4,15 @@ This package provides MCP tools for accessing MoneyWiz SQLite database,
 enabling AI assistants to perform financial analysis and transaction management.
 """
 
-__version__ = "1.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
 __author__ = "Juan Carlos Valerio Arrieta"
 __email__ = "jcvalerio@gmail.com"
+
+try:
+    __version__ = version("moneywiz-mcp-server")
+except PackageNotFoundError:  # pragma: no cover - only possible outside installs
+    __version__ = "0.0.0"
 
 # Re-export main components for easier imports
 from .config import Config

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -1,0 +1,10 @@
+"""Tests for package metadata helpers."""
+
+from importlib.metadata import version
+
+import moneywiz_mcp_server
+
+
+def test_package_version_matches_installed_metadata() -> None:
+    """Package __version__ should reflect installed distribution metadata."""
+    assert moneywiz_mcp_server.__version__ == version("moneywiz-mcp-server")


### PR DESCRIPTION
## Summary
- derive moneywiz_mcp_server.__version__ from installed package metadata
- add a regression test to ensure __version__ matches distribution metadata
- document Claude Desktop configuration for running the published PyPI package with uvx
- document the changes in the changelog

## Checks
- uv run ruff check . --output-format=github
- uv run ruff format --check .
- uv run mypy src/ --install-types --non-interactive --no-strict-optional
- uv run pytest tests/ (148 passed)
- uv build
- uvx twine check dist/*

## Notes
- Source-checkout Claude Desktop guidance remains documented.
- PyPI/uvx guidance uses an env block for MONEYWIZ_DB_PATH because there is no checkout-local .env in that mode.
- No MCP tool schema changes.
- No configuration requirement changes for existing users.
- No financial calculation changes.